### PR TITLE
Update from mail 'educacio'

### DIFF
--- a/opt/xtecmail/lib.php
+++ b/opt/xtecmail/lib.php
@@ -8,7 +8,7 @@ class xtecmail {
     private $allowed_senders = array(
         'xtec' => 'correus_aplicacions.educacio@xtec.cat',
         'gencat' => 'correus_aplicacions.educacio@gencat.cat',
-        'educacio' => 'apligest@correueducacio.xtec.cat',
+        'educacio' => 'correus_aplicacions.educacio@gencat.cat',
     );
 
 


### PR DESCRIPTION
S'ha modificat el codi de la llibreria d'enviament de correus del from "correus_aplicacions.educacio@xtec.cat" al nou from "correus_aplicacions.educacio@gencat.cat".